### PR TITLE
Fix: Unmarshal issue with Block functions

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -70,22 +70,22 @@ func (c *client) BlockHexByHeight(ctx context.Context, height int) (string, erro
 }
 
 func (c *client) BlockDecodeHeader(ctx context.Context, hash string) (*models.BlockDecodeHeader, error) {
-	var resp models.BlockDecodeHeader
+	resp := models.BlockDecodeHeader{BlockHeader: models.BlockHeader{BlockHeader: &bc.BlockHeader{}}}
 	return &resp, c.rpc.Do(ctx, "getblock", &resp, hash, models.VerbosityDecodeHeader)
 }
 
 func (c *client) BlockDecodeHeaderByHeight(ctx context.Context, height int) (*models.BlockDecodeHeader, error) {
-	var resp models.BlockDecodeHeader
+	resp := models.BlockDecodeHeader{BlockHeader: models.BlockHeader{BlockHeader: &bc.BlockHeader{}}}
 	return &resp, c.rpc.Do(ctx, "getblockbyheight", &resp, height, models.VerbosityDecodeHeader)
 }
 
 func (c *client) Block(ctx context.Context, hash string) (*models.Block, error) {
-	var resp models.Block
+	resp := models.Block{BlockHeader: models.BlockHeader{BlockHeader: &bc.BlockHeader{}}}
 	return &resp, c.rpc.Do(ctx, "getblock", &resp, hash, models.VerbosityDecodeTransactions)
 }
 
 func (c *client) BlockByHeight(ctx context.Context, height int) (*models.Block, error) {
-	var resp models.Block
+	resp := models.Block{BlockHeader: models.BlockHeader{BlockHeader: &bc.BlockHeader{}}}
 	return &resp, c.rpc.Do(ctx, "getblockbyheight", &resp, height, models.VerbosityDecodeTransactions)
 }
 

--- a/models/block.go
+++ b/models/block.go
@@ -22,21 +22,31 @@ type Block struct {
 
 // UnmarshalJSON unmarshal response.
 func (b *Block) UnmarshalJSON(bb []byte) error {
-	bj := struct {
-		Txs json.RawMessage `json:"tx"`
+	bh := struct {
 		BlockHeader
+	}{
+		BlockHeader: BlockHeader{
+			BlockHeader: &bc.BlockHeader{},
+		},
+	}
+	if err := json.Unmarshal(bb, &bh); err != nil {
+		return err
+	}
+
+	btxs := struct {
+		Txs json.RawMessage `json:"tx"`
 	}{}
-	if err := json.Unmarshal(bb, &bj); err != nil {
+	if err := json.Unmarshal(bb, &btxs); err != nil {
 		return err
 	}
 
 	var txs bt.Txs
-	if err := json.Unmarshal(bj.Txs, txs.NodeJSON()); err != nil {
+	if err := json.Unmarshal(btxs.Txs, txs.NodeJSON()); err != nil {
 		return err
 	}
 
 	b.Txs = txs
-	b.BlockHeader = bj.BlockHeader
+	b.BlockHeader = bh.BlockHeader
 	return nil
 }
 


### PR DESCRIPTION
To avoid nil pointer, instantiate all data before handing off to rpc.

To avoid a quirk(?) in golang's json unmarshalling, perform unmarshalling twice on the block response via anonymous structs.